### PR TITLE
Fix `up` slashcommand

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -306,7 +306,7 @@ var snuslashcommands = {
         "hint": "UnManadtory; Set all mandatory fields to false (Admin only)"
     },
     "up": {
-        "url": "sys_ui_policy_list.do?sysparm_query=nameLIKE$0^ORDERBYDESCsys_updated_on",
+        "url": "sys_ui_policy_list.do?sysparm_query=short_descriptionLIKE$0^ORDERBYDESCsys_updated_on",
         "hint": "UI Policies <name>",
         "fields": "name"
     },


### PR DESCRIPTION
UI Policies use short description instead of name as the primary identifier